### PR TITLE
Apply requested substitutions to the original source

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,7 @@ module.exports = function (registry) {
     const doc = parent.getDocument()
     const subs = attrs.subs
     if (subs) {
-      source = doc.$apply_subs(attrs.subs, doc.$resolve_subs(subs))
+      source = doc.$apply_subs(source, doc.$resolve_subs(subs))
     }
     var svgText
     try {


### PR DESCRIPTION
I ran into this in a document with a _*bunch*_ of `bytefield` displays, where I wanted/needed to reduce the duplication of the same `(defattrs ...)` over and over again.  By using:

```
:bytefieldDefaults: (defattrs :plain {:font-family "inherit" :font-size 14})

[bytefield,subs=attributes]
----
{bytefieldDefaults}

(draw-column-headers)
(draw-box "foo")
(draw-column-bottom)
----
```

I expected to be able to inject some common defaults.  Instead, I got a "Could not resolve symbol: normal [at line 1, column 1]" error.

Digging into the code, I found that the `extension.js` line 19 was using `attrs.subs` as the "source" argument to `$apply_subs()`, rather than passing the original source.  Using `source` here seems to fix things.