### PR TITLE
Add js/String

### DIFF
--- a/doc/modules/ROOT/pages/funcs.adoc
+++ b/doc/modules/ROOT/pages/funcs.adoc
@@ -18,8 +18,9 @@ and http://cljs.github.io/api/clojure.string[`clojure.string`] are
 also made available, so you can call functions from them if needed.
 
 The JavaScript
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String[`String`] and
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math[`Math`
-object] is also available, so you can use it to perform mathematical
+object] are also available. The latter so you can perform mathematical
 computations using JavaScript interop syntax. For example here's how
 you would calculate stem:[2^8]:
 
@@ -78,6 +79,37 @@ and include: `xml/add-attrs`, `xml/add-content`, `xml/emit`,
 
 If you understand the structures built and used by Analemma, you can
 also build them directly yourself and pass them to `append-svg`.
+
+
+[[char-arrow-int]]
+== char->int
+
+Get the UTF-16 code unit of a character.
+
+.Arguments
+[source,clojure]
+----
+[char]
+----
+
+This is equivalent to e.g. `(int \H)` in Clojure.
+
+Example:
+
+[source,clojure]
+(draw-related-boxes (number-as-bits (char->int \H) 8))
+
+
+[bytefield]
+----
+(def boxes-per-row 8)
+(def left-margin 1)
+(draw-related-boxes (number-as-bits (char->int \H) 8))
+
+----
+
+
+
 
 [[defattrs]]
 == defattrs

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -864,7 +864,8 @@
            opts {:preset      :termination-safe
                  :realize-max 10000
                  :env         env
-                 :classes     {'Math js/Math}
+                 :classes     {'Math   js/Math
+                               'String js/String}
                  :namespaces  {'user           (merge diagram-bindings @*globals*)
                                'analemma.svg   svg-bindings
                                'analemma.xml   xml-bindings

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -303,6 +303,11 @@
     :else
     (throw (js/Error. (str "Don't know how to format box label: " label)))))
 
+(defn char->int
+  "Yields the UTF-16 code unit of a character. E.g. `(char->int \\A) ;; => 65`."
+  [char]
+  (.charCodeAt ^String char))
+
 (defn normalize-bit
   "Converts a value to either `true` or `false`. All non-zero numbers
   become `true`. Other values are tested for truthiness and translated
@@ -697,6 +702,7 @@
   "Our own functions which we want to make available for building
   diagrams."
   (self-bind-symbols [append-svg
+                      char->int
                       defattrs
                       draw-bottom
                       draw-box


### PR DESCRIPTION
This allows for the clj-equivalent of `(int \a)`, i.e. `(.charCodeAt \a)`.