### PR TITLE
Small typos

### DIFF
--- a/doc/modules/ROOT/pages/attrs.adoc
+++ b/doc/modules/ROOT/pages/attrs.adoc
@@ -36,7 +36,7 @@ yourself, such as when you want to tell `draw-box` to consume the
 space normally taken by two boxes:
 
 [source,clojure]
-(draw-box 42 {:span 2}}
+(draw-box 42 {:span 2})
 
 The second argument to `draw-box` is an attribute expression. In this
 case we have told it that the `:span` attribute should have the value
@@ -92,7 +92,7 @@ diagram has called `defattrs` to set up the `:bg-purple` style), that
 takes up the space of four normal boxes:
 
 [source,clojure]
-(draw-box "Unknown" [:box-related :bg-purple {:span 4}]))
+(draw-box "Unknown" [:box-related :bg-purple {:span 4}])
 
 === No Attributes
 


### PR DESCRIPTION
Some small fixes in the documentation.  
One fix was done earlier but only applied to a guide-X-branch, and not applied to the mainline. 