### PR TITLE
Added fill styling of boxes with gaps and inline gaps

### DIFF
--- a/doc/modules/ROOT/pages/funcs.adoc
+++ b/doc/modules/ROOT/pages/funcs.adoc
@@ -754,6 +754,8 @@ second argument). For example, use `{:box-above-style
  must be available in the current row if the label is to be drawn
  in it.
 
+|:fill |N/A |The fill color to use as the box background. 
+
 |===
 
 NOTE: In order to allow you to draw boxes that connect to the bottom
@@ -765,14 +767,14 @@ the gap.
 
 [source,clojure]
 (draw-box "Stuff" {:span 4})
-(draw-gap "A gap")
+(draw-gap "A gap" {:fill "#ffffa0"})
 (draw-box "More stuff")
 (draw-bottom)
 
 [bytefield]
 ----
 (draw-box "Stuff" {:span 2})
-(draw-gap "A gap")
+(draw-gap "A gap" {:fill "#ffffa0"})
 (draw-box "More stuff" {:span 4})
 (draw-bottom)
 ----
@@ -820,21 +822,24 @@ row or column headers because they will be incorrect.
 |:width |15 |The width of the gap context, which is sandwiched between
  the edges and affects the slope of the gap within it, drawn from the
  top right of this section to the bottom left.
+
+|:fill |N/A |The fill color to use as the box background.
+
 |===
 
 If you want to label the inline gap, draw an open-ended box on either
 side of it and label that:
 
 [source,clojure]
-(draw-box "name" {:span 2 :borders #{:left :top :bottom}})
-(draw-gap-inline)
+(draw-box "name" {:span 2 :borders #{:left :top :bottom :fill "#ffffa0"}})
+(draw-gap-inline {:fill "#ffffa0"})
 (draw-box "port" {:span 2})
 
 
 [bytefield]
 ----
-(draw-box "name" {:span 2 :borders #{:left :top :bottom}})
-(draw-gap-inline)
+(draw-box "name" {:span 2 :borders #{:left :top :bottom} :fill "#ffffa0"})
+(draw-gap-inline {:fill "#ffffa0"})
 (draw-box "port" {:span 2})
 ----
 

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -624,17 +624,41 @@
          top       (diagram-height)
          left      (+ @('left-margin @*globals*) (* column box-width))
          bottom    (+ top height)
-         right     (+ left box-width)]
+         right     (+ left box-width)
+         left-trapezoid { 
+           :top-left [left top],
+           :top-right [(+ left edge (- width gap)) top],
+           :bottom-left [left bottom],
+           :bottom-right [(+ left edge) bottom]
+         }
+         right-trapezoid { 
+           :top-left [(- right edge) top], 
+           :top-right [right top],
+           :bottom-left [(- right edge (- width gap)) bottom],
+           :bottom-right [right bottom]
+         }]
      (when fill [
-      (append-svg (svg/polygon [left top (+ left edge (- width gap)) top (+ left edge) bottom left bottom] :fill fill))
-      (append-svg (svg/polygon [right top (- right edge) top (- right edge (- width gap)) bottom right bottom] :fill fill))
+      (append-svg (svg/polygon (concat
+        (left-trapezoid :top-left)
+        (left-trapezoid :top-right)
+        (left-trapezoid :bottom-right)
+        (left-trapezoid :bottom-left)
+        ) :fill fill
+      ))
+      (append-svg (svg/polygon (concat
+        (right-trapezoid :top-left)
+        (right-trapezoid :top-right)
+        (right-trapezoid :bottom-right)
+        (right-trapezoid :bottom-left)
+        ) :fill fill
+      ))
      ])
-     (draw-line left top (+ left edge (- width gap)) top)
-     (draw-line (+ left edge (- width gap)) top (+ left edge) bottom gap-style)
-     (draw-line (+ left edge) bottom left bottom)
-     (draw-line right top (- right edge) top)
-     (draw-line (- right edge) top (- right edge (- width gap)) bottom gap-style)
-     (draw-line (- right edge (- width gap)) bottom right bottom))
+     (apply draw-line (concat (left-trapezoid :top-left) (left-trapezoid :top-right)))
+     (apply draw-line (concat (left-trapezoid :top-right) (left-trapezoid :bottom-right) [gap-style]))
+     (apply draw-line (concat (left-trapezoid :bottom-right) (left-trapezoid :bottom-left)))
+     (apply draw-line (concat (right-trapezoid :top-right) (right-trapezoid :top-left)))
+     (apply draw-line (concat (right-trapezoid :top-left) (right-trapezoid :bottom-left) [gap-style]))
+     (apply draw-line (concat (right-trapezoid :bottom-left) (right-trapezoid :bottom-right))))
    (swap! @('diagram-state @*globals*) update :column inc)))
 
 (defn draw-bottom

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -585,18 +585,19 @@
                  min-label-columns 8}} attrs
 
          column (:column @@('diagram-state @*globals*))
-         boxes  @('boxes-per-row @*globals*)]
+         boxes  @('boxes-per-row @*globals*)
+         fill-style (when fill {:fill fill})]
      (if label
        ;; We are supposed to draw a label.
        (if (<= min-label-columns (- boxes column))
-         (draw-box label [{:span (- boxes column)} box-above-style (if (nil? fill) {} {:fill fill})]) ; And there is room for it on the current line.
+         (draw-box label [{:span (- boxes column)} box-above-style fill-style]) ; And there is room for it on the current line.
          (do ; The label doesn't fit on the current line.
-           (draw-box nil [{:span (- boxes column)} box-above-style (if (nil? fill) {} {:fill fill})]) ; Finish off current line with emptiness.
+           (draw-box nil [{:span (- boxes column)} box-above-style fill-style]) ; Finish off current line with emptiness.
            (auto-advance-row nil)
-           (draw-box label [{:span boxes :borders #{:left :right}} (if (nil? fill) {} {:fill fill})]))) ; Put the label on its own line.
+           (draw-box label [{:span boxes :borders #{:left :right}} fill-style]))) ; Put the label on its own line.
        ;; We are not supposed to draw a label, so just finish the current line if needed.
        (when (not= column boxes)
-         (draw-box nil [{:span (- boxes column)} :box-above (if (nil? fill) {} {:fill fill})]))) ; Finish off current line with emptiness.
+         (draw-box nil [{:span (- boxes column)} :box-above fill-style]))) ; Finish off current line with emptiness.
 
      ;; Move on to a new row to draw the gap.
      (auto-advance-row nil)

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -529,25 +529,25 @@
        bottom-left
        ) :fill fill))
     )
-  (if (or (= trapezoid-type "upper") (= trapezoid-type "lower"))
+  (if (or (= trapezoid-type :trapezoid-type/upper) (= trapezoid-type :trapezoid-type/lower))
     [
       (apply draw-line (concat top-left bottom-left))
       (apply draw-line (concat top-right bottom-right))
-      (if(= trapezoid-type "upper")
+      (if(= trapezoid-type :trapezoid-type/upper)
         (apply draw-line (concat bottom-left bottom-right [gap-style]))
-        (if(= trapezoid-type "lower")
+        (if(= trapezoid-type :trapezoid-type/lower)
           (apply draw-line (concat top-left top-right [gap-style]))
           ()
         )
       )
     ]
-    (if (or (= trapezoid-type "left") (= trapezoid-type "right"))
+    (if (or (= trapezoid-type :trapezoid-type/left) (= trapezoid-type :trapezoid-type/right))
       [
         (apply draw-line (concat top-left top-right))
         (apply draw-line (concat bottom-left bottom-right))
-        (if(= trapezoid-type "left")
+        (if(= trapezoid-type :trapezoid-type/left)
         (apply draw-line (concat top-right bottom-right [gap-style]))
-        (if(= trapezoid-type "right")
+        (if(= trapezoid-type :trapezoid-type/right)
           (apply draw-line (concat top-left bottom-left [gap-style]))
           ()
         )
@@ -629,7 +629,7 @@
             (upper-trapezoid :top-right)
             (upper-trapezoid :bottom-right)
             (upper-trapezoid :bottom-left)
-            "upper"
+            :trapezoid-type/upper
             fill
             gap-style)
       (draw-gap-trapezoid 
@@ -637,7 +637,7 @@
             (lower-trapezoid :top-right)
             (lower-trapezoid :bottom-right)
             (lower-trapezoid :bottom-left)
-            "lower"
+            :trapezoid-type/lower
             fill
             gap-style))
      (let [state     (swap! @('diagram-state @*globals*)
@@ -705,7 +705,7 @@
       (left-trapezoid :top-right)
       (left-trapezoid :bottom-right)
       (left-trapezoid :bottom-left)
-      "left"
+      :trapezoid-type/left
       fill
       gap-style
      )
@@ -714,7 +714,7 @@
       (right-trapezoid :top-right)
       (right-trapezoid :bottom-right)
       (right-trapezoid :bottom-left)
-      "right"
+      :trapezoid-type/right
       fill
       gap-style
      ))

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -603,7 +603,8 @@
   box width.
 
   As with `draw-box`, the row height defaults to the predefined value
-  `row-height` but can be overridden through `:height`.
+  `row-height` but can be overridden through `:height`. The background
+  can be filled with a color passed with `:fill`.
 
   Since there are no clearly defined use cases that identify where and
   how to position any label, it is the responsibility of the

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -612,7 +612,7 @@
   ([]
    (draw-gap-inline nil))
   ([attr-spec]
-   (let [{:keys [width height gap gap-style]
+   (let [{:keys [width height gap gap-style fill]
           :or   {width     15
                  height    @('row-height @*globals*)
                  gap       5
@@ -625,6 +625,10 @@
          left      (+ @('left-margin @*globals*) (* column box-width))
          bottom    (+ top height)
          right     (+ left box-width)]
+     (when fill [
+      (append-svg (svg/polygon [left top (+ left edge (- width gap)) top (+ left edge) bottom left bottom] :fill fill))
+      (append-svg (svg/polygon [right top (- right edge) top (- right edge (- width gap)) bottom right bottom] :fill fill))
+     ])
      (draw-line left top (+ left edge (- width gap)) top)
      (draw-line (+ left edge (- width gap)) top (+ left edge) bottom gap-style)
      (draw-line (+ left edge) bottom left bottom)

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -530,6 +530,7 @@
         (apply draw-line (concat bottom-left bottom-right [gap-style]))
         (if(= trapezoid-type "lower")
           (apply draw-line (concat top-left top-right [gap-style]))
+          ()
         )
       )
     ]
@@ -541,9 +542,11 @@
         (apply draw-line (concat top-right bottom-right [gap-style]))
         (if(= trapezoid-type "right")
           (apply draw-line (concat top-left bottom-left [gap-style]))
+          ()
         )
       )
       ]
+      ()
     )
   )
 ))
@@ -575,15 +578,15 @@
   ([label]
    (draw-gap label nil))
   ([label attr-spec]
-   (let [attrs (eval-attribute-spec attr-spec)]
-   (let [{:keys [height gap edge gap-style box-above-style min-label-columns fill]
+   (let [attrs                     (eval-attribute-spec attr-spec)
+         {:keys [height gap edge gap-style box-above-style min-label-columns fill]
           :or   {height            70
                  gap               10
                  edge              15
                  gap-style         (eval-attribute-spec :dotted)
                  box-above-style   (eval-attribute-spec :box-above)
                  min-label-columns 8}} attrs
-
+                 
          column (:column @@('diagram-state @*globals*))
          boxes  @('boxes-per-row @*globals*)
          fill-style (when fill {:fill fill})]
@@ -606,18 +609,14 @@
            left   @('left-margin @*globals*)
            right  (+ left (diagram-width))
            bottom (+ y (- height edge))
-           upper-trapezoid { 
-            :top-left [left y],
-            :top-right [right y],
-            :bottom-left [left top],
-            :bottom-right [right (- bottom gap)]
-           }
-           lower-trapezoid { 
-            :top-left [left (+ top gap)], 
-            :top-right [right bottom],
-            :bottom-left [left (+ y height)],
-            :bottom-right [right (+ y height)]
-           }]
+           upper-trapezoid {:top-left [left y],
+                            :top-right [right y],
+                            :bottom-left [left top],
+                            :bottom-right [right (- bottom gap)]}
+           lower-trapezoid {:top-left [left (+ top gap)], 
+                            :top-right [right bottom],
+                            :bottom-left [left (+ y height)],
+                            :bottom-right [right (+ y height)]}]
       (draw-gap-trapezoid 
             (upper-trapezoid :top-left)
             (upper-trapezoid :top-right)
@@ -625,8 +624,7 @@
             (upper-trapezoid :bottom-left)
             "upper"
             fill
-            gap-style
-       )
+            gap-style)
       (draw-gap-trapezoid 
             (lower-trapezoid :top-left)
             (lower-trapezoid :top-right)
@@ -634,8 +632,7 @@
             (lower-trapezoid :bottom-left)
             "lower"
             fill
-            gap-style
-       ))
+            gap-style))
      (let [state     (swap! @('diagram-state @*globals*)
                             (fn [current]
                               (-> current
@@ -643,7 +640,7 @@
                                   (assoc :address 0)
                                   (assoc :gap? true))))
            header-fn @('row-header-fn @*globals*)]
-       (when header-fn (draw-row-header (header-fn state))))))))
+       (when header-fn (draw-row-header (header-fn state)))))))
 
 (defn draw-gap-inline
   "Draws an indication of discontinuity for a single-row diagram. Takes
@@ -688,36 +685,32 @@
          left      (+ @('left-margin @*globals*) (* column box-width))
          bottom    (+ top height)
          right     (+ left box-width)
-         left-trapezoid { 
-           :top-left [left top],
-           :top-right [(+ left edge (- width gap)) top],
-           :bottom-left [left bottom],
-           :bottom-right [(+ left edge) bottom]
-         }
-         right-trapezoid { 
-           :top-left [(- right edge) top], 
-           :top-right [right top],
-           :bottom-left [(- right edge (- width gap)) bottom],
-           :bottom-right [right bottom]
-         }]
+         left-trapezoid {:top-left [left top],
+                         :top-right [(+ left edge (- width gap)) top],
+                         :bottom-left [left bottom],
+                         :bottom-right [(+ left edge) bottom]}
+         right-trapezoid {:top-left [(- right edge) top], 
+                          :top-right [right top],
+                          :bottom-left [(- right edge (- width gap)) bottom],
+                          :bottom-right [right bottom]}]
      (draw-gap-trapezoid 
-            (left-trapezoid :top-left)
-            (left-trapezoid :top-right)
-            (left-trapezoid :bottom-right)
-            (left-trapezoid :bottom-left)
-            "left"
-            fill
-            gap-style
-       )
-      (draw-gap-trapezoid 
-            (right-trapezoid :top-left)
-            (right-trapezoid :top-right)
-            (right-trapezoid :bottom-right)
-            (right-trapezoid :bottom-left)
-            "right"
-            fill
-            gap-style
-       ))
+      (left-trapezoid :top-left)
+      (left-trapezoid :top-right)
+      (left-trapezoid :bottom-right)
+      (left-trapezoid :bottom-left)
+      "left"
+      fill
+      gap-style
+     )
+     (draw-gap-trapezoid 
+      (right-trapezoid :top-left)
+      (right-trapezoid :top-right)
+      (right-trapezoid :bottom-right)
+      (right-trapezoid :bottom-left)
+      "right"
+      fill
+      gap-style
+     ))
    (swap! @('diagram-state @*globals*) update :column inc)))
 
 (defn draw-bottom

--- a/src/org/deepsymmetry/bytefield/core.cljs
+++ b/src/org/deepsymmetry/bytefield/core.cljs
@@ -513,6 +513,13 @@
    (draw-related-boxes (repeat (- address (next-address)) label) attr-spec)))
 
 (defn- draw-gap-trapezoid
+  "A private function used by draw-gap and draw-inline-gap for drawing
+  trapezoids. The first four arguments specifies the trapezoid's
+  vertices. The fifth argument is the trapezoid's 'type' e.g. upper, 
+  lower, left or right. This type is used to calculate on which edge
+  the 'gap' should appear. The sixth argument is the fill parameter 
+  for the trapezoid. The seventh parameter is the specification for
+  styling the gap."  
   ([top-left top-right bottom-right bottom-left trapezoid-type fill gap-style]
    (when fill 
      (append-svg (svg/polygon (concat
@@ -586,7 +593,7 @@
                  gap-style         (eval-attribute-spec :dotted)
                  box-above-style   (eval-attribute-spec :box-above)
                  min-label-columns 8}} attrs
-                 
+
          column (:column @@('diagram-state @*globals*))
          boxes  @('boxes-per-row @*globals*)
          fill-style (when fill {:fill fill})]


### PR DESCRIPTION
Borrowed the following fill styling logic from the `draw-box` function:
https://github.com/Deep-Symmetry/bytefield-svg/blob/a13edf0e5e31fabba1f798106dfb89a0d5f4f439/src/org/deepsymmetry/bytefield/core.cljs#L426
Adapted it to utilise svg `polygon`s using the Analemma dependency's [polygon function](https://github.com/liebke/analemma/blob/2488d690e19bc254296e6e838fcfdb14a190328d/src/analemma/svg.cljc#L49-L54), supplying a list of points from the already computed `line` parameters.

- Fixes #48 
- Subsequently added functionality to apply fill styling to `draw-gap` function calls too.