### PR TITLE
Fixed styling in ethernet II example

### DIFF
--- a/doc/modules/ROOT/examples/ethernet.edn
+++ b/doc/modules/ROOT/examples/ethernet.edn
@@ -3,7 +3,7 @@
 (draw-box "Source MAC" {:span 6})
 (draw-box "(802.1Q tag)" {:span 4})
 
-(draw-box (text "Ethertype" {:font-size 16}) {:span 2})
+(draw-box (text "Ethertype" [:plain {:font-size 16}]) {:span 2})
 (draw-gap "Payload")
 (draw-bottom)
 (draw-box "FCS" {:span 4})


### PR DESCRIPTION
On refreshing my memory of bytefield-svg's syntax, I noticed the [Ethernet II](https://bytefield-svg.deepsymmetry.org/bytefield-svg/examples.html#_ethernet_ii_frame_dix_v2_0) example's `Ethertype` field was styled differently to other fields.

This PR introduces a vector for the styling of the field,  adding the `:plain` keyword to the pre-existing font-size map `{:font-size 16}`.