### PR TITLE
fix draw-gap-inline example code

### DIFF
--- a/doc/modules/ROOT/pages/funcs.adoc
+++ b/doc/modules/ROOT/pages/funcs.adoc
@@ -831,7 +831,7 @@ If you want to label the inline gap, draw an open-ended box on either
 side of it and label that:
 
 [source,clojure]
-(draw-box "name" {:span 2 :borders #{:left :top :bottom :fill "#ffffa0"}})
+(draw-box "name" {:span 2 :borders #{:left :top :bottom} :fill "#ffffa0"})
 (draw-gap-inline {:fill "#ffffa0"})
 (draw-box "port" {:span 2})
 


### PR DESCRIPTION
In the example code the :fill attribute was placed inside the :borders map. The :fill attribute is not nested within :borders, but on the same level. This is also the case in the example code for the rendered image.